### PR TITLE
Remove usages of Thread.sleep in the acceptance tests

### DIFF
--- a/src/test/scala/uk/gov/hmrc/api/specs/BaseSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/api/specs/BaseSpec.scala
@@ -16,18 +16,22 @@
 
 package uk.gov.hmrc.api.specs
 
+import org.scalatest.GivenWhenThen
+import org.scalatest.concurrent.Eventually
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.GivenWhenThen
+import org.scalatest.time.{Millis, Span}
 import uk.gov.hmrc.api.conf.TestConfiguration
 
-import scala.concurrent.{Await, Awaitable, Future}
-import scala.concurrent.duration.Duration
 import scala.concurrent.duration.*
+import scala.concurrent.{Await, Awaitable}
 
-trait BaseSpec extends AnyFeatureSpec, GivenWhenThen, Matchers:
+trait BaseSpec extends AnyFeatureSpec, GivenWhenThen, Matchers, Eventually:
   val host: String         = TestConfiguration.url("central-reference-data-inbound-orchestrator")
   val testOnlyHost: String = TestConfiguration.testOnlyUrl("central-reference-data-inbound-orchestrator")
+
+  // This configuration determines how long `eventually` will wait for its assertions to become true
+  override given patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(5500, Millis))
 
   def await[T](f: Awaitable[T], timeout: Duration = 10.seconds): T =
     Await.result(f, timeout)

--- a/src/test/scala/uk/gov/hmrc/api/specs/SdesCallbackController.scala
+++ b/src/test/scala/uk/gov/hmrc/api/specs/SdesCallbackController.scala
@@ -26,8 +26,8 @@ class SdesCallbackController extends BaseSpec, HttpClient:
   Feature("User can test Inbound POST API for SDES notification") {
     Scenario("Inbound POST API handles successful SDES notification") {
       Given("The endpoint is accessed")
-      val id             = UUID.randomUUID().toString
-      val _              = await(
+      val id     = UUID.randomUUID().toString
+      val _      = await(
         post(
           host,
           xmlFullMessageFromID(id),
@@ -35,8 +35,8 @@ class SdesCallbackController extends BaseSpec, HttpClient:
           "x-files-included" -> "true"
         )
       )
-      val url            = s"$host/services/crdl/callback"
-      val result         = await(
+      val url    = s"$host/services/crdl/callback"
+      val result = await(
         post(
           url,
           successJsonBodyFromString(id),
@@ -44,22 +44,22 @@ class SdesCallbackController extends BaseSpec, HttpClient:
         )
       )
       result.status shouldBe 202
-      // The code being run is asynchronous,we need to sleep to make sure that it has finished processing.otherwise we do not see anything different when we check the state.
-      Thread.sleep(5500)
-      val testOnlyUrl    = s"$testOnlyHost/message-wrappers/$id"
-      val wrapper_status = await(
-        get(
-          testOnlyUrl
+      eventually {
+        val testOnlyUrl    = s"$testOnlyHost/message-wrappers/$id"
+        val wrapper_status = await(
+          get(
+            testOnlyUrl
+          )
         )
-      )
-      wrapper_status.status        shouldBe 202
-      wrapper_status.body.toString shouldBe "ScanPassed"
+        wrapper_status.status        shouldBe 202
+        wrapper_status.body.toString shouldBe "ScanPassed"
+      }
     }
 
     Scenario("Inbound POST API handles sent SDES notification") {
       Given("The endpoint is accessed")
-      val id             = UUID.randomUUID().toString
-      val _              = await(
+      val id     = UUID.randomUUID().toString
+      val _      = await(
         post(
           host,
           xmlFullMessageFromID(id),
@@ -67,8 +67,8 @@ class SdesCallbackController extends BaseSpec, HttpClient:
           "x-files-included" -> "true"
         )
       )
-      val url            = s"$host/services/crdl/callback"
-      val result         = await(
+      val url    = s"$host/services/crdl/callback"
+      val result = await(
         post(
           url,
           fileProcessedJsonBodyFromString(id),
@@ -76,16 +76,16 @@ class SdesCallbackController extends BaseSpec, HttpClient:
         )
       )
       result.status shouldBe 202
-      // The code being run is asynchronous,we need to sleep to make sure that it has finished processing.otherwise we do not see anything different when we check the state.
-      Thread.sleep(5500)
-      val testOnlyUrl    = s"$testOnlyHost/message-wrappers/$id"
-      val wrapper_status = await(
-        get(
-          testOnlyUrl
+      eventually {
+        val testOnlyUrl    = s"$testOnlyHost/message-wrappers/$id"
+        val wrapper_status = await(
+          get(
+            testOnlyUrl
+          )
         )
-      )
-      wrapper_status.status        shouldBe 202
-      wrapper_status.body.toString shouldBe "Sent"
+        wrapper_status.status        shouldBe 202
+        wrapper_status.body.toString shouldBe "Sent"
+      }
     }
 
     Scenario("Inbound POST API handles failure SDES notification") {


### PR DESCRIPTION
This PR removes some usages of `Thread.sleep` in the acceptance tests - this causes linting warnings on our PRs and it's better to use ScalaTest's built-in support for [eventually](https://www.scalatest.org/scaladoc/3.2.19/org/scalatest/concurrent/Eventually.html), which repeatedly tests that an assertion is true until it reaches a configurable timeout.